### PR TITLE
downgrade to java 8

### DIFF
--- a/facturx_validator/README.rst
+++ b/facturx_validator/README.rst
@@ -17,7 +17,7 @@ This tool is a bit complex to install because it uses several Java components.
 
 .. code::
 
-  sudo apt install default-jre maven
+  sudo apt install openjdk-8-jdk maven
 
 Get veraPDF-rest, the tool that analyse the PDF/A conformity:
 


### PR DESCRIPTION
e.g. on Debian 8, Maven will install java 11, which is too high for verapdf rest api (when starting, one will get a  java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException since that had been moved)